### PR TITLE
Patches: Disabling fancybox on selected images and fix false positives

### DIFF
--- a/fancybox.php
+++ b/fancybox.php
@@ -175,7 +175,7 @@ jQuery.fn.getTitle = function() { // Copy the title of every IMG tag and add it 
 }
 
 // Supported file extensions
-var thumbnails = jQuery("a:has(img)").not(".nolightbox").filter( function() { return /(jpe?g|png|gif|bmp)$/i.test(jQuery(this).attr('href')) });
+var thumbnails = jQuery("a:has(img)").not(".nolightbox").filter( function() { return /\.(jpe?g|png|gif|bmp)$/i.test(jQuery(this).attr('href')) });
 
 <?php if ( $settings['galleryType'] == 'post' ) {
 


### PR DESCRIPTION
Add support for disabling fancybox on individual hyperlinked images by adding class='nolightbox' (the class name is generic on purpose)

Also see http://wordpress.org/support/topic/plugin-fancybox-for-wordpress-patch-heres-how-to-add-support-for-disabling-fancybox-on-select-images

---

Fix Fancybox false positives.

Also see http://wordpress.org/support/topic/plugin-fancybox-for-wordpress-fancybox-false-positives
