### PR TITLE
Update to 3.1.3

### DIFF
--- a/fancybox.php
+++ b/fancybox.php
@@ -4,7 +4,7 @@
 Plugin Name: FancyBox for WordPress
 Plugin URI: https://wordpress.org/plugins/fancybox-for-wordpress/
 Description: Integrates <a href="http://fancyapps.com/fancybox/3/">FancyBox 3</a> into WordPress.
-Version: 3.1.2
+Version: 3.1.3
 Author: Colorlib
 Author URI: https://colorlib.com/wp/
 
@@ -19,7 +19,7 @@ Author URI: https://colorlib.com/wp/
  * Plugin Init
  */
 // Constants
-define( 'FBFW_VERSION', '3.1.2' );
+define( 'FBFW_VERSION', '3.1.3' );
 define( 'FBFW_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FBFW_URL', plugin_dir_url( __FILE__ ) );
 define( 'FBFW_PLUGIN_BASE', plugin_basename( __FILE__ ) );

--- a/fancybox.php
+++ b/fancybox.php
@@ -275,7 +275,7 @@ function mfbfw_init() {
 		}
 
 		// Supported file extensions
-		var thumbnails = jQuery("a:has(img)").not(".nolightbox").filter( function() { return /\.(jpe?g|png|gif|bmp)$/i.test(jQuery(this).attr('href')) });
+		var thumbnails = jQuery("a:has(img)").not(".nolightbox").filter( function() { return /\.(jpe?g|png|gif|bmp|pdf)\?.+$/i.test(jQuery(this).attr('href')) });
 		<?php if ( $mfbfw['galleryType'] == 'post' ) { ?>
 
 			// Gallery type BY POST and on post or page (so only one post or page is visible)

--- a/fancybox.php
+++ b/fancybox.php
@@ -208,12 +208,12 @@ function mfbfw_init() {
 
 	if ( $mfbfw['titlePosition'] == 'inside' ) {
 		$afterLoad = 'function( instance, current ) {';
-		$afterLoad .= 'current.$content.append(\'<div class=\"fancybox-custom-caption\" style=\" position: absolute;left:0;right:0;color:#000;padding-top:10px;bottom:-50px;background:#fff;margin:0 auto;text-align:center; \">\' + current.opts.caption + \'</div>\');';
+		$afterLoad .= 'current.$content.append(\'<div class=\"fancybox-custom-caption\" style=\" position: absolute;left:0;right:0;color:#000;padding-top:10px;bottom:-50px;margin:0 auto;text-align:center; \">\' + current.opts.caption + \'</div>\');';
 		$afterLoad .= '}';
 		$hideCaption = 'div.fancybox-caption{display:none !important;}';
 	} else if ( $mfbfw['titlePosition'] == 'over' ) {
 		$afterLoad = 'function( instance, current ) {';
-		$afterLoad .= 'current.$content.append(\'<div class=\"fancybox-custom-caption\" style=\" position: absolute;left:0;right:0;color:#000;padding-top:10px;bottom:0;background:#fff;margin:0 auto;text-align:center; \">\' + current.opts.caption + \'</div>\');';
+		$afterLoad .= 'current.$content.append(\'<div class=\"fancybox-custom-caption\" style=\" position: absolute;left:0;right:0;color:#000;padding-top:10px;bottom:0;margin:0 auto;text-align:center; \">\' + current.opts.caption + \'</div>\');';
 		$afterLoad .= '}';
 		$hideCaption = 'div.fancybox-caption{display:none !important;}';
 	} else {
@@ -253,7 +253,7 @@ function mfbfw_init() {
 <style type="text/css">
 	'.$hideCaption.'
 	' . ( isset( $mfbfw['overlayShow'] ) ? '' : 'div.fancybox-bg{background:transparent !important;}' ) . '
-	' . 'img.fancybox-image{border-width:' . $mfbfw['padding'] . 'px;border-color:' . $mfbfw['paddingColor'] . ';border-style:solid;}' . '
+	' . 'img.fancybox-image{border-width:' . $mfbfw['padding'] . 'px;border-color:' . $mfbfw['paddingColor'] . ';border-style:solid;height:auto;}' . '
 	' . ( isset( $mfbfw['overlayColor'] ) && $mfbfw['overlayColor'] ? 'div.fancybox-bg{background-color:' . hexTorgba( $mfbfw['overlayColor'], $mfbfw['overlayOpacity'] ) . ';opacity:1 !important;}' : '' ) . ( isset( $mfbfw['paddingColor'] ) && $mfbfw['paddingColor'] ? 'div.fancybox-content{border-color:' . $mfbfw['paddingColor'] . '}' : '' ) . '
 	' . ( isset( $mfbfw['paddingColor'] ) && $mfbfw['paddingColor'] && $mfbfw['titlePosition'] == 'inside' ? 'div#fancybox-title{background-color:' . $mfbfw['paddingColor'] . '}' : '' ) . '
 	div.fancybox-content{background-color:' . $mfbfw['paddingColor'] . ( isset( $mfbfw['border'] ) && $mfbfw['border'] ? ';border:1px solid ' . $mfbfw['borderColor'] : '' ) . '}

--- a/lib/class-fbfw-plugin-rollback.php
+++ b/lib/class-fbfw-plugin-rollback.php
@@ -44,27 +44,26 @@ class FBFW_Plugin_RollBack {
 
         if ( class_exists( 'FBFW_Rollback' ) ) {
             $rollback = new FBFW_Rollback(
-                [
+                array(
                     'version'     => FBFW_PREVIOUS_PLUGIN_VERSION,
                     'plugin_name' => FBFW_PLUGIN_BASE,
                     'plugin_slug' => $plugin_slug,
                     'package_url' => sprintf( 'https://downloads.wordpress.org/plugin/%s.%s.zip', PLUGIN_NAME, FBFW_PREVIOUS_PLUGIN_VERSION ),
-                ]
+                )
             );
             $rollback->run();
         }
 
         wp_die(
-            '', __( 'Rollback to Previous Version', 'mfbfw' ), [
+            '', __( 'Rollback to Previous Version', 'mfbfw' ), array(
                 'response' => 200,
-            ]
+            )
         );
     }
 
     public function rollback_scripts() {
         wp_enqueue_script('rollback-script', FBFW_URL . 'assets/js/rollback.js', FBFW_VERSION); // Load Rollback script
         wp_enqueue_script( 'rollback-script' );
-
     }
 
 }

--- a/lib/class-fbfw-rollback.php
+++ b/lib/class-fbfw-rollback.php
@@ -72,7 +72,7 @@ class FBFW_Rollback {
      *
      * @param array $args Optional. Rollback arguments. Default is an empty array.
      */
-    public function __construct( $args = [] ) {
+    public function __construct( $args = array() ) {
         foreach ( $args as $key => $value ) {
             $this->{$key} = $value;
         }
@@ -150,12 +150,12 @@ class FBFW_Rollback {
 
         $logo_url = FBFW_URL . 'assets/images/icon.jpg';
 
-        $upgrader_args = [
+        $upgrader_args = array(
             'url'    => 'update.php?action=upgrade-plugin&plugin=' . rawurlencode( $this->plugin_name ),
             'plugin' => $this->plugin_name,
             'nonce'  => 'upgrade-plugin_' . $this->plugin_name,
             'title'  => '<img src="' . $logo_url . '" alt="FBFW logo">' . __( 'Rollback to Previous Version', 'epfw' ),
-        ];
+        );
 
         $this->print_inline_style();
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: silkalns
 Tags: fancybox, lightbox, jquery, gallery, image, images, photo, photos, picture, pictures, zoom
 Requires at least: 3.4
 Tested up to: 4.9
-Stable tag: 3.1.2
+Stable tag: 3.1.3
 License: GPL/MIT
 
 Seamlessly integrates FancyBox lightbox into your WordPress blog: Upload, activate, and you're done. Additional configuration optional.
@@ -30,6 +30,11 @@ If you are new to WordPress and want to lear more we have got you covered. Color
 If you enjoy using FancyBox lightbox for WordPress please leave a [positive feedback](https://wordpress.org/support/plugin/fancybox-for-wordpress/reviews/?filter=5). We are committed to make it the best lightbox plugin for WordPress.
 
 == Changelog ==
+
+= 3.1.3 =
+* Fixed "Parse error" - https://wordpress.org/support/topic/no-backend-after-fancybox-update/
+* Fixed "Breaks on query strings" - https://wordpress.org/support/topic/url-with-ssl1-fancybox-doesnt-open/
+* Fixed "Caption problems" - https://wordpress.org/support/topic/border-not-fitting-and-strange-white-line/
 
 = 3.1.2 =
 * Fixed "All links get the fancybox class"


### PR DESCRIPTION
Fixed "Parse error" - https://wordpress.org/support/topic/no-backend-after-fancybox-update/
Fixed "Breaks on query strings" - https://wordpress.org/support/topic/url-with-ssl1-fancybox-doesnt-open/
Fixed "Caption problems" - https://wordpress.org/support/topic/border-not-fitting-and-strange-white-line/